### PR TITLE
Added migration file to update all Organizations subdomain in production

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,7 +3,7 @@ class Organization < ApplicationRecord
   has_many :wishlists, dependent: :destroy
   has_many :wishes, through: :wishlists
   validates :name, presence: true, uniqueness: true
-  validates :subdomain, presence: true, uniqueness: true, format: { with: /\A\w+\z/ }
+  validates :subdomain, presence: true, uniqueness: true, format: { with: /\A[\w\-]+\z/ }
   before_save :titleize_name
   has_one_attached :logo
 

--- a/db/migrate/20231023103344_add_subdomains_to_companies.rb
+++ b/db/migrate/20231023103344_add_subdomains_to_companies.rb
@@ -1,0 +1,8 @@
+class AddSubdomainsToCompanies < ActiveRecord::Migration[7.0]
+  def change
+    Organization.all.each do |organization|
+      organization.update(subdomain: organization.name.downcase.gsub(/\s+/, '-')) if organization.subdomain.nil?
+      SubdomainCreator.new(organization.subdomain).call
+    end
+  end
+end


### PR DESCRIPTION
When we will run `rails db:migrate` in production it will automatically update all organizations to have a subdomain and it will call the Heroku API to create a subdomain for it. 🥳